### PR TITLE
fix: remove usage hashValues in favor Object.hash

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Flutter
       uses: subosito/flutter-action@v1
       with:
-        flutter-version: '2.0.3'
+        flutter-version: '3.27.3'
     - name: Install dependencies
       run: flutter pub get
     - name: Run dart analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+* Flutter 3.27.1 compatibility, replace `ui.hash*` with `Object.hash*
+
 ## 1.3.0
 
 * Animate marker position changes instead of removing and re-adding

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -89,7 +89,7 @@ class InfoWindow {
   }
 
   @override
-  int get hashCode => hashValues(title.hashCode, snippet, anchor);
+  int get hashCode => Object.hash(title.hashCode, snippet, anchor);
 
   @override
   String toString() {

--- a/lib/src/annotation_updates.dart
+++ b/lib/src/annotation_updates.dart
@@ -87,7 +87,7 @@ class _AnnotationUpdates {
 
   @override
   int get hashCode =>
-      hashValues(annotationsToAdd, annotationIdsToRemove, annotationsToChange);
+      Object.hash(annotationsToAdd, annotationIdsToRemove, annotationsToChange);
 
   @override
   String toString() {

--- a/lib/src/camera.dart
+++ b/lib/src/camera.dart
@@ -73,7 +73,7 @@ class CameraPosition {
   }
 
   @override
-  int get hashCode => hashValues(heading, target, pitch, zoom);
+  int get hashCode => Object.hash(heading, target, pitch, zoom);
 
   @override
   String toString() =>

--- a/lib/src/circle_updates.dart
+++ b/lib/src/circle_updates.dart
@@ -87,7 +87,7 @@ class _CircleUpdates {
 
   @override
   int get hashCode =>
-      hashValues(circlesToAdd, circleIdsToRemove, circlesToChange);
+      Object.hash(circlesToAdd, circleIdsToRemove, circlesToChange);
 
   @override
   String toString() {

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -44,7 +44,7 @@ class LatLng {
   }
 
   @override
-  int get hashCode => hashValues(latitude, longitude);
+  int get hashCode => Object.hash(latitude, longitude);
 }
 
 /// A latitude/longitude aligned rectangle.
@@ -116,5 +116,5 @@ class LatLngBounds {
   }
 
   @override
-  int get hashCode => hashValues(southwest, northeast);
+  int get hashCode => Object.hash(southwest, northeast);
 }

--- a/lib/src/polygon_updates.dart
+++ b/lib/src/polygon_updates.dart
@@ -87,7 +87,7 @@ class _PolygonUpdates {
 
   @override
   int get hashCode =>
-      hashValues(polygonsToAdd, polygonIdsToRemove, polygonsToChange);
+      Object.hash(polygonsToAdd, polygonIdsToRemove, polygonsToChange);
 
   @override
   String toString() {

--- a/lib/src/polyline_updates.dart
+++ b/lib/src/polyline_updates.dart
@@ -81,7 +81,7 @@ class _PolylineUpdates {
 
   @override
   int get hashCode =>
-      hashValues(polylinesToAdd, polylineIdsToRemove, polylinesToChange);
+      Object.hash(polylinesToAdd, polylineIdsToRemove, polylinesToChange);
 
   @override
   String toString() {

--- a/lib/src/snapshot_options.dart
+++ b/lib/src/snapshot_options.dart
@@ -45,7 +45,7 @@ class SnapshotOptions {
   }
 
   @override
-  int get hashCode => hashValues(showBuildings, showPointsOfInterest);
+  int get hashCode => Object.hash(showBuildings, showPointsOfInterest);
 
   @override
   String toString() =>

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -86,7 +86,7 @@ class MinMaxZoomPreference {
   }
 
   @override
-  int get hashCode => hashValues(minZoom, maxZoom);
+  int get hashCode => Object.hash(minZoom, maxZoom);
 
   @override
   String toString() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.3.0
+version: 1.4.0
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Following https://github.com/flutter/flutter/issues/85431, this commit allows the library to work under latest Flutter version 3.27.1